### PR TITLE
add prisma seed & add Account logic

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -13,6 +13,7 @@ import { IPrismaService } from './database/IPrismaService';
 
 /** Entities */
 import { IUserController } from './entities/user/interfaces/IUserController';
+import { IAccountController } from './entities/account/interfaces/IAccountController';
 
 @injectable()
 export class App {
@@ -26,6 +27,7 @@ export class App {
     @inject(TYPES.ConfigService) private _configService: IConfigService,
     @inject(TYPES.PrismaService) private _prismaService: IPrismaService,
     @inject(TYPES.UserController) private _userController: IUserController,
+    @inject(TYPES.AccountController) private _accountController: IAccountController,
   ) {
     this.app = express();
     this.port = Number(process.env.PORT) || 3333;
@@ -39,6 +41,7 @@ export class App {
 
   useRoutes(): void {
     this.app.use('/auth', this._userController.router);
+    this.app.use('/account', this._accountController.router);
   }
 
   useExceptionFilters(): void {

--- a/apps/server/src/common/middlewares/login.middleware.ts
+++ b/apps/server/src/common/middlewares/login.middleware.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction } from 'express';
+import { verify } from 'jsonwebtoken';
+
+import { IMiddleware } from '../interfaces/IMiddleware';
+
+type TokenData = {
+  userId: string;
+  email: string;
+};
+
+export class LoginMiddleware implements IMiddleware {
+  #secret: string;
+
+  constructor(secret: string) {
+    this.#secret = secret;
+  }
+
+  #verifyToken(req: Request, accessToken: string, next: NextFunction): Promise<TokenData> {
+    return new Promise((resolve, reject) => {
+      verify(accessToken, this.#secret, (err: unknown, payload: TokenData) => {
+        if (err) {
+          return reject(err);
+        } else if (payload && typeof payload === 'object') {
+          resolve(payload);
+        }
+      });
+    });
+  }
+
+  async execute(req: Request, res: Response, next: NextFunction): Promise<void> {
+    if (!req.headers.authorization) {
+      return next(new Error('Missing Auth'));
+    }
+    const accessToken = req.headers.authorization.split(' ')[1];
+    try {
+      const tokenData = await this.#verifyToken(req, accessToken, next);
+      if (!tokenData.userId) {
+        return next(new Error('Missing Auth'));
+      }
+      req.userId = tokenData.userId;
+      req.email = tokenData.email;
+      next();
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/server/src/common/middlewares/validate-params.middleware.ts
+++ b/apps/server/src/common/middlewares/validate-params.middleware.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+import { ClassConstructor, plainToClass } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { IMiddleware } from '../interfaces/IMiddleware';
+
+export class ValidateParamsMiddleware implements IMiddleware {
+  #classToValidate: ClassConstructor<object>;
+
+  constructor(classToValidate: ClassConstructor<object>) {
+    this.#classToValidate = classToValidate;
+  }
+
+  execute(req: Request, res: Response, next: NextFunction): void {
+    const instance = plainToClass(this.#classToValidate, req.params);
+
+    validate(instance).then((errors) => {
+      if (errors.length) {
+        res.status(422).send(errors);
+      } else {
+        next();
+      }
+    });
+  }
+}

--- a/apps/server/src/entities/account/account.controller.ts
+++ b/apps/server/src/entities/account/account.controller.ts
@@ -1,0 +1,157 @@
+import { Request, Response, NextFunction } from 'express';
+import { inject, injectable } from 'inversify';
+
+import { TYPES } from '../../types';
+import { BaseController } from '../../common/base.controller';
+import { IControllerRoute } from '../../common/interfaces/IControllerRoute';
+import { IAccountController } from './interfaces/IAccountController';
+import { IAccountService } from './interfaces/IAccountService';
+import { ILoggerService } from '../../logger/ILoggerService';
+import { IConfigService } from '../../config/IConfigService';
+
+import { LoginMiddleware } from '../../common/middlewares/login.middleware';
+import { ValidateMiddleware } from '../../common/middlewares/validate.middleware';
+import { ValidateParamsMiddleware } from '../../common/middlewares/validate-params.middleware';
+import { HttpError } from '../../errors/HttpError';
+
+import { AccountCreateDto } from './dto/account-create.dto';
+import { AccountUpdateDto } from './dto/account-update.dto';
+import { AccountGetByIdDto } from './dto/account-get-by-id.dto';
+
+@injectable()
+export class AccountController extends BaseController implements IAccountController {
+  readonly routes: IControllerRoute[] = [
+    {
+      path: '/info',
+      method: 'get',
+      callback: this.info,
+    },
+    {
+      path: '/create',
+      method: 'post',
+      callback: this.create,
+      middlewares: [new ValidateMiddleware(AccountCreateDto)],
+    },
+    {
+      path: '/:id',
+      method: 'put',
+      callback: this.update,
+      middlewares: [
+        new ValidateMiddleware(AccountUpdateDto),
+        new ValidateParamsMiddleware(AccountGetByIdDto),
+      ],
+    },
+    {
+      path: '/:id',
+      method: 'delete',
+      callback: this.delete,
+      middlewares: [new ValidateParamsMiddleware(AccountGetByIdDto)],
+    },
+    {
+      path: '/:id',
+      method: 'get',
+      callback: this.getById,
+      middlewares: [new ValidateParamsMiddleware(AccountGetByIdDto)],
+    },
+  ];
+
+  constructor(
+    @inject(TYPES.ConfigService) private _configService: IConfigService,
+    @inject(TYPES.Logger) private _logger: ILoggerService,
+    @inject(TYPES.AccountService) private _accountService: IAccountService,
+  ) {
+    super(_logger);
+
+    const loginMiddleware = new LoginMiddleware(this._configService.getConfig<string>('SECRET'));
+
+    this.routes = this.routes.map((route) => {
+      return {
+        ...route,
+        middlewares: [...(route.middlewares || []), loginMiddleware],
+      };
+    });
+
+    this.bindRoutes(this.routes);
+  }
+
+  public async create(
+    req: Request<any, any, AccountCreateDto>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const userId = Number(req.userId);
+      const body = req.body;
+      body.userId = userId;
+      const result = await this._accountService.createAccount(body);
+      if (!result) {
+        return next(new HttpError(401, 'Account error', 'Create'));
+      }
+
+      this.success(res, result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async update(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = Number(req.userId);
+      const accountId = Number(req.params.id);
+      const accountData = req.body;
+      accountData.userId = userId;
+      const result = await this._accountService.updateAccount(accountId, accountData);
+      if (!result) {
+        return next(new HttpError(401, 'Account error', 'Update'));
+      }
+
+      this.success(res, result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async delete(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = Number(req.userId);
+      const accountId = Number(req.params.id);
+      const result = await this._accountService.deleteAccount(accountId, userId);
+      if (!result) {
+        return next(new HttpError(401, 'Account error', 'Delete'));
+      }
+
+      this.success(res, result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getById(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = Number(req.userId);
+      const accountId = Number(req.params.id);
+      const result = await this._accountService.getAccountById(accountId, userId);
+      if (!result) {
+        throw new HttpError(404, 'Account not found', 'Get');
+      }
+
+      this.success(res, result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async info(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const userId = Number(req.userId);
+      const result = await this._accountService.getAccounts(userId);
+      if (!result) {
+        throw new HttpError(404, 'Accounts not found', 'Get');
+      }
+
+      this.success(res, result);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/server/src/entities/account/account.entity.ts
+++ b/apps/server/src/entities/account/account.entity.ts
@@ -1,0 +1,53 @@
+enum AccountType {
+  WALLET = 'WALLET',
+  CARD = 'CARD',
+}
+
+export class Account {
+  #name: string;
+  #description: string | null;
+  #balance: number;
+  #type: AccountType;
+  #userId: number;
+  #currencyId: number;
+
+  constructor(
+    name: string,
+    description: string | null,
+    balance: number,
+    type: AccountType,
+    userId: number,
+    currencyId: number,
+  ) {
+    this.#name = name;
+    this.#description = description;
+    this.#balance = balance;
+    this.#type = type;
+    this.#userId = userId;
+    this.#currencyId = currencyId;
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  get description(): string | null {
+    return this.#description;
+  }
+
+  get balance(): number {
+    return this.#balance;
+  }
+
+  get type(): AccountType {
+    return this.#type;
+  }
+
+  get userId(): number {
+    return this.#userId;
+  }
+
+  get currencyId(): number {
+    return this.#currencyId;
+  }
+}

--- a/apps/server/src/entities/account/account.repository.ts
+++ b/apps/server/src/entities/account/account.repository.ts
@@ -1,0 +1,58 @@
+import { Account as AccountModel, Prisma } from '@prisma/client';
+import { inject, injectable } from 'inversify';
+
+import { TYPES } from '../../types';
+import { IPrismaService } from '../../database/IPrismaService';
+import { IAccountRepository } from './interfaces/IAccountRepository';
+import { Account } from './account.entity';
+
+@injectable()
+export class AccountRepository implements IAccountRepository {
+  constructor(@inject(TYPES.PrismaService) private _prismaService: IPrismaService) {}
+
+  async create(accountData: Account): Promise<AccountModel> {
+    return await this._prismaService.client.account.create({
+      data: {
+        name: accountData.name,
+        description: accountData.description,
+        balance: accountData.balance,
+        type: accountData.type,
+        userId: accountData.userId,
+        currencyId: accountData.currencyId,
+      },
+    });
+  }
+
+  async update(accountId: number, accountData: Account): Promise<AccountModel> {
+    return await this._prismaService.client.account.update({
+      where: {
+        id: accountId,
+      },
+      data: accountData,
+    });
+  }
+
+  async delete(accountId: number): Promise<AccountModel | null> {
+    return await this._prismaService.client.account.delete({
+      where: {
+        id: accountId,
+      },
+    });
+  }
+
+  async findById(accountId: number): Promise<AccountModel | null> {
+    return await this._prismaService.client.account.findUniqueOrThrow({
+      where: {
+        id: accountId,
+      },
+    });
+  }
+
+  async find(userId: number): Promise<AccountModel[] | null> {
+    return await this._prismaService.client.account.findMany({
+      where: {
+        userId: userId,
+      },
+    });
+  }
+}

--- a/apps/server/src/entities/account/account.service.ts
+++ b/apps/server/src/entities/account/account.service.ts
@@ -1,0 +1,73 @@
+import { inject, injectable } from 'inversify';
+import { Account as AccountModel, AccountType } from '@prisma/client';
+
+import { TYPES } from '../../types';
+import { IAccountService } from './interfaces/IAccountService';
+import { IConfigService } from '../../config/IConfigService';
+import { IAccountRepository } from './interfaces/IAccountRepository';
+
+import { Account } from './account.entity';
+import { AccountCreateDto } from './dto/account-create.dto';
+import { AccountUpdateDto } from './dto/account-update.dto';
+
+@injectable()
+export class AccountService implements IAccountService {
+  constructor(
+    @inject(TYPES.ConfigService) private _configService: IConfigService,
+    @inject(TYPES.AccountRepository) private _accountRepository: IAccountRepository,
+  ) {}
+
+  async createAccount({
+    name,
+    description,
+    type,
+    userId,
+    balance,
+    currencyId,
+  }: AccountCreateDto): Promise<AccountModel | null> {
+    const newAccount = new Account(
+      name,
+      description,
+      balance,
+      AccountType[type],
+      userId,
+      currencyId,
+    );
+    return this._accountRepository.create(newAccount);
+  }
+
+  async updateAccount(
+    accountId: number,
+    accountData: AccountUpdateDto,
+  ): Promise<AccountModel | null> {
+    const account = await this.find(accountId);
+    if (account.userId != accountData.userId) {
+      return null;
+    }
+    return this._accountRepository.update(accountId, accountData);
+  }
+
+  async deleteAccount(accountId: number, userId: number): Promise<AccountModel | null> {
+    const account = await this.find(accountId);
+    if (account.userId != userId) {
+      return null;
+    }
+    return this._accountRepository.delete(accountId);
+  }
+
+  async getAccountById(accountId: number, userId: number): Promise<AccountModel | null> {
+    const account = await this.find(accountId);
+    if (account.userId != userId) {
+      return null;
+    }
+    return account;
+  }
+
+  async getAccounts(userId: number): Promise<AccountModel[] | null> {
+    return this._accountRepository.find(userId);
+  }
+
+  private async find(accountId: number): Promise<AccountModel | null> {
+    return this._accountRepository.findById(accountId);
+  }
+}

--- a/apps/server/src/entities/account/dto/account-create.dto.ts
+++ b/apps/server/src/entities/account/dto/account-create.dto.ts
@@ -1,0 +1,24 @@
+import { IsOptional, IsString, IsNumber, Min, IsEnum } from 'class-validator';
+
+export class AccountCreateDto {
+  @IsString({ message: 'Incorrect name' })
+  name: string;
+
+  @IsOptional()
+  @IsString({ message: 'Incorrect description' })
+  description: string;
+
+  @IsNumber({}, { message: 'Invalid balance' })
+  @Min(0, { message: 'Balance must be a positive number' })
+  balance: number;
+
+  @IsEnum(['WALLET', 'CARD'], { message: 'Invalid account type' })
+  type: string;
+
+  @IsNumber({}, { message: 'Invalid currency ID' })
+  currencyId: number;
+
+  @IsOptional()
+  @IsNumber({}, { message: 'Invalid user ID' })
+  userId: number;
+}

--- a/apps/server/src/entities/account/dto/account-get-by-id.dto.ts
+++ b/apps/server/src/entities/account/dto/account-get-by-id.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class AccountGetByIdDto {
+  @Transform(({ value }) => Number(value))
+  @IsInt({ message: 'Account ID must be an integer' })
+  @Min(1, { message: 'Account ID must be greater than or equal to 1' })
+  id: number;
+}

--- a/apps/server/src/entities/account/dto/account-update.dto.ts
+++ b/apps/server/src/entities/account/dto/account-update.dto.ts
@@ -1,0 +1,24 @@
+import { IsOptional, IsString, IsNumber, Min, IsEnum } from 'class-validator';
+
+export class AccountUpdateDto {
+  @IsString({ message: 'Incorrect name' })
+  name: string;
+
+  @IsOptional()
+  @IsString({ message: 'Incorrect description' })
+  description: string;
+
+  @IsNumber({}, { message: 'Invalid balance' })
+  @Min(0, { message: 'Balance must be a positive number' })
+  balance: number;
+
+  @IsEnum(['WALLET', 'CARD'], { message: 'Invalid account type' })
+  type: string;
+
+  @IsOptional()
+  @IsNumber({}, { message: 'Invalid user ID' })
+  userId: number;
+
+  @IsNumber({}, { message: 'Invalid currency ID' })
+  currencyId: number;
+}

--- a/apps/server/src/entities/account/interfaces/IAccountController.ts
+++ b/apps/server/src/entities/account/interfaces/IAccountController.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { BaseController } from '../../../common/base.controller';
+import { IControllerRoute } from '../../../common/interfaces/IControllerRoute';
+
+export interface IAccountController extends BaseController {
+  routes: IControllerRoute[];
+  create: (req: Request, res: Response, next: NextFunction) => void;
+  update: (req: Request, res: Response, next: NextFunction) => void;
+  delete: (req: Request, res: Response, next: NextFunction) => void;
+  getById: (req: Request, res: Response, next: NextFunction) => void;
+  info: (req: Request, res: Response, next: NextFunction) => void;
+}

--- a/apps/server/src/entities/account/interfaces/IAccountRepository.ts
+++ b/apps/server/src/entities/account/interfaces/IAccountRepository.ts
@@ -1,0 +1,12 @@
+import { Account as AccountModel } from '@prisma/client';
+import { Account } from '../account.entity';
+
+import { AccountUpdateDto } from '../dto/account-update.dto';
+
+export interface IAccountRepository {
+  create: (account: Account) => Promise<AccountModel>;
+  update: (id: number, account: AccountUpdateDto) => Promise<AccountModel>;
+  delete: (id: number) => Promise<AccountModel | null>;
+  findById: (id: number) => Promise<AccountModel | null>;
+  find: (userId: number) => Promise<AccountModel[] | null>;
+}

--- a/apps/server/src/entities/account/interfaces/IAccountService.ts
+++ b/apps/server/src/entities/account/interfaces/IAccountService.ts
@@ -1,0 +1,12 @@
+import { Account as AccountModel } from '@prisma/client';
+
+import { AccountCreateDto } from '../dto/account-create.dto';
+import { AccountUpdateDto } from '../dto/account-update.dto';
+
+export interface IAccountService {
+  createAccount: (dto: AccountCreateDto) => Promise<AccountModel | null>;
+  updateAccount: (accountId: number, dto: AccountUpdateDto) => Promise<AccountModel | null>;
+  deleteAccount: (accountId: number, userId: number) => Promise<AccountModel | null>;
+  getAccountById: (accountId: number, userId: number) => Promise<AccountModel | null>;
+  getAccounts: (userId: number) => Promise<AccountModel[] | null>;
+}

--- a/apps/server/src/entities/user/interfaces/IUserService.ts
+++ b/apps/server/src/entities/user/interfaces/IUserService.ts
@@ -5,6 +5,6 @@ import { UserRegisterDto } from '../dto/user-register.dto';
 
 export interface IUserService {
   createUser: (dto: UserRegisterDto) => Promise<UserModel | null>;
-  loginUser: (dto: UserLoginDto) => Promise<boolean>;
+  loginUser: (dto: UserLoginDto) => Promise<number | boolean>;
   getUserInfo: (email: string) => Promise<Omit<UserModel, 'password'> | null>;
 }

--- a/apps/server/src/entities/user/user.controller.ts
+++ b/apps/server/src/entities/user/user.controller.ts
@@ -54,12 +54,12 @@ export class UserController extends BaseController implements IUserController {
     res: Response,
     next: NextFunction,
   ): Promise<void> {
-    const result = await this._userService.loginUser(body);
-    if (!result) {
+    const userId = await this._userService.loginUser(body);
+    if (!userId) {
       return next(new HttpError(401, 'Authorization error', 'Login'));
     }
 
-    const jwt = await this.#signJWT(body.email, this._configService.getConfig('SECRET'));
+    const jwt = await this.#signJWT(body.email, userId, this._configService.getConfig('SECRET'));
     this.success(res, { accessToken: jwt });
   }
 
@@ -81,11 +81,12 @@ export class UserController extends BaseController implements IUserController {
     this.success(res, result);
   }
 
-  #signJWT(email: string, secret: string): Promise<string> {
+  #signJWT(email: string, userId: number | boolean, secret: string): Promise<string> {
     return new Promise((resolve, reject) => {
       sign(
         {
           email,
+          userId,
           iat: Math.floor(Date.now() / 1000),
         },
         secret,

--- a/apps/server/src/entities/user/user.service.ts
+++ b/apps/server/src/entities/user/user.service.ts
@@ -17,12 +17,15 @@ export class UserService implements IUserService {
     @inject(TYPES.UserRepository) private _userRepository: IUserRepository,
   ) {}
 
-  async loginUser({ email, password }: UserLoginDto): Promise<boolean> {
+  async loginUser({ email, password }: UserLoginDto): Promise<number | boolean> {
     const existedUser = await this._userRepository.find(email);
     if (!existedUser) return false;
 
     const newUser = new User(existedUser.email, existedUser.name);
-    return newUser.comparePasswords(password, existedUser.password);
+    if (!newUser.comparePasswords(password, existedUser.password)) {
+      return false;
+    }
+    return existedUser.id;
   }
 
   async createUser({ email, name, password }: UserRegisterDto): Promise<UserModel | null> {

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -10,6 +10,9 @@ import { IPrismaService } from './database/IPrismaService';
 import { IUserController } from './entities/user/interfaces/IUserController';
 import { IUserService } from './entities/user/interfaces/IUserService';
 import { IUserRepository } from './entities/user/interfaces/IUserRepository';
+import { IAccountController } from './entities/account/interfaces/IAccountController';
+import { IAccountService } from './entities/account/interfaces/IAccountService';
+import { IAccountRepository } from './entities/account/interfaces/IAccountRepository';
 
 /** Utils */
 import { ConfigService } from './config/config.service';
@@ -21,6 +24,9 @@ import { ExceptionFilter } from './errors/ExceptionFilter';
 import { UserController } from './entities/user/user.controller';
 import { UserService } from './entities/user/user.service';
 import { UserRepository } from './entities/user/user.repository';
+import { AccountController } from './entities/account/account.controller';
+import { AccountService } from './entities/account/account.service';
+import { AccountRepository } from './entities/account/account.repository';
 
 import { App } from './app';
 
@@ -33,12 +39,15 @@ export interface IBootstrapReturn {
 export const appBindings = new ContainerModule((bind: interfaces.Bind) => {
   bind<App>(TYPES.Application).to(App);
   bind<IUserController>(TYPES.UserController).to(UserController);
+  bind<IAccountController>(TYPES.AccountController).to(AccountController);
   bind<IUserService>(TYPES.UserService).to(UserService);
+  bind<IAccountService>(TYPES.AccountService).to(AccountService);
   bind<IExceptionFilter>(TYPES.ExceptionFilter).to(ExceptionFilter);
   bind<ILoggerService>(TYPES.Logger).to(LoggerService).inSingletonScope();
   bind<IConfigService>(TYPES.ConfigService).to(ConfigService).inSingletonScope();
   bind<IPrismaService>(TYPES.PrismaService).to(PrismaService).inSingletonScope();
   bind<IUserRepository>(TYPES.UserRepository).to(UserRepository).inSingletonScope();
+  bind<IAccountRepository>(TYPES.AccountRepository).to(AccountRepository).inSingletonScope();
 });
 
 async function bootstrap(): Promise<IBootstrapReturn> {

--- a/apps/server/src/types/custom.d.ts
+++ b/apps/server/src/types/custom.d.ts
@@ -1,5 +1,6 @@
 declare namespace Express {
   export interface Request {
     email: string;
+    userId: string;
   }
 }

--- a/apps/server/src/types/index.ts
+++ b/apps/server/src/types/index.ts
@@ -11,4 +11,7 @@ export const TYPES = {
   UserService: Symbol.for('UserService'),
   UserController: Symbol.for('UserController'),
   UserRepository: Symbol.for('UserRepository'),
+  AccountService: Symbol.for('AccountService'),
+  AccountController: Symbol.for('AccountController'),
+  AccountRepository: Symbol.for('AccountRepository'),
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "update-packages": "npx npm-check-updates -u",
     "nx": "nx serve server"
   },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
+  },
   "private": true,
   "dependencies": {
     "@prisma/client": "^4.15.0",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,41 @@
+import { PrismaClient } from '@prisma/client'
+const prisma = new PrismaClient()
+async function main() {
+  const rubl = await prisma.currency.upsert({
+    where: { id: 1 },
+    update: {},
+    create: {
+      name: 'рубль',
+      shortName: 'руб',
+      logoUrl: '',
+    },
+  })
+  const dollar = await prisma.currency.upsert({
+    where: { id: 2 },
+    update: {},
+    create: {
+      name: 'доллар',
+      shortName: 'дол',
+      logoUrl: '',
+    },
+  })
+  const euro = await prisma.currency.upsert({
+    where: { id: 3 },
+    update: {},
+    create: {
+      name: 'евро',
+      shortName: 'евр',
+      logoUrl: '',
+    },
+  })
+  console.log({ rubl, dollar, euro })
+}
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
+  })


### PR DESCRIPTION
Добавлены сиды для добавления в базу 3 основных валют: рубль, доллар и евро. Пути к картинкам не прописывал, т.к. не знаю, где они будут лежать на фронте. Отправлю картинки в дискорд.
Чтобы добавить сиды себе в базу необходимо прописать команду:
**npx prisma db seed**
Добавлено сохранение userId в jwt токен, т.к. он нужен почти везде.
Добавлен middleware, который не дает работать с логикой счетов без jwt токена.
Добавлена вся логика работы со счетами.